### PR TITLE
feat: add NTAG215/216 NDEF text record parser for filament

### DIFF
--- a/klippy/extras/filament_detect.py
+++ b/klippy/extras/filament_detect.py
@@ -124,6 +124,14 @@ class FilamentDetector:
                     filament_info = info
                 else:
                     logging.error("channel[%d] m1 parse err: %d", channel, error)
+            elif (fm175xx_reader.FM175XX_MIFARE_CARD_TYPE_NTAG == card_type and fm175xx_reader.FM175XX_OK == result):
+                logging.info("channel[%d] ntag card data parsing....", channel)
+                error, info = filament_protocol.ntag_ndef_data_parse(card_data)
+                if (error == filament_protocol.FILAMENT_PROTO_OK):
+                    logging.info("channel[%d] ntag parse ok....", channel)
+                    filament_info = info
+                else:
+                    logging.error("channel[%d] ntag parse err: %d", channel, error)
         else:
             is_clear = True
 

--- a/klippy/extras/filament_protocol.py
+++ b/klippy/extras/filament_protocol.py
@@ -82,6 +82,15 @@ FILAMENT_PROTO_COLOR_NUMS_MAX                   = 5
 
 # Filament Tag type
 FILAMENT_PROTO_TAG_M1                           = 'M1_1K'
+FILAMENT_PROTO_TAG_NTAG                         = 'NTAG'
+
+# Material types supported for NTAG NDEF parsing
+# Must match keys in filament_parameters.FILAMENT_PARA_CFG_DEFAULT
+NTAG_SUPPORTED_MATERIAL_TYPES = {
+    'PLA', 'PLA-CF', 'PETG', 'PETG-CF', 'PETG-HF', 'PCTG',
+    'ABS', 'ASA', 'TPU', 'PVA', 'PA', 'PA-CF', 'PA6-CF',
+    'PA-GF', 'PA6-GF', 'PC', 'PC-ABS', 'EVA',
+}
 
 # M1 card protocol
 M1_PROTO_TOTAL_SIZE                             = 1024
@@ -432,6 +441,127 @@ def m1_proto_data_parse(data_buf):
     info['CARD_UID'] = data_buf[M1_PROTO_UID_POS : M1_PROTO_UID_POS + M1_PROTO_UID_LEN]
 
     info['OFFICIAL'] = True
+
+    return FILAMENT_PROTO_OK, info
+
+def ntag_ndef_data_parse(data_buf):
+    """Parse NTAG215/216 user memory containing an NDEF Text Record.
+
+    Expected NDEF text payload format: MATERIAL#RRGGBB
+    Example: PLA#FF5733
+
+    Args:
+        data_buf: list of ints, raw bytes from NTAG page 4 onward
+
+    Returns:
+        (FILAMENT_PROTO_OK, info_dict) on success
+        (FILAMENT_PROTO_ERR, None) on parse failure
+    """
+    if data_buf is None or not isinstance(data_buf, list) or len(data_buf) < 16:
+        return FILAMENT_PROTO_PARAMETER_ERR, None
+
+    try:
+        # Find NDEF Message TLV (type=0x03) in TLV block
+        offset = 0
+        ndef_data = None
+        while offset < len(data_buf) - 1:
+            tlv_type = data_buf[offset]
+            if tlv_type == 0x00:
+                # NULL TLV, skip
+                offset += 1
+                continue
+            if tlv_type == 0xFE:
+                # Terminator TLV
+                break
+            if offset + 1 >= len(data_buf):
+                break
+            tlv_len = data_buf[offset + 1]
+            if tlv_len == 0xFF:
+                # 3-byte length format
+                if offset + 3 >= len(data_buf):
+                    break
+                tlv_len = (data_buf[offset + 2] << 8) | data_buf[offset + 3]
+                tlv_value_start = offset + 4
+            else:
+                tlv_value_start = offset + 2
+
+            if tlv_type == 0x03:
+                # NDEF Message TLV found
+                tlv_value_end = tlv_value_start + tlv_len
+                if tlv_value_end > len(data_buf):
+                    return FILAMENT_PROTO_ERR, None
+                ndef_data = data_buf[tlv_value_start:tlv_value_end]
+                break
+
+            # Skip unknown TLV
+            offset = tlv_value_start + tlv_len
+
+        if ndef_data is None or len(ndef_data) < 3:
+            return FILAMENT_PROTO_ERR, None
+
+        # Parse NDEF Record header
+        header = ndef_data[0]
+        tnf = header & 0x07
+        type_len = ndef_data[1]
+        # Short Record (SR) bit check
+        if header & 0x10:
+            payload_len = ndef_data[2]
+            rec_type_start = 3
+        else:
+            if len(ndef_data) < 6:
+                return FILAMENT_PROTO_ERR, None
+            payload_len = ((ndef_data[2] << 24) | (ndef_data[3] << 16) |
+                           (ndef_data[4] << 8) | ndef_data[5])
+            rec_type_start = 6
+
+        rec_type = ndef_data[rec_type_start:rec_type_start + type_len]
+        payload_start = rec_type_start + type_len
+        payload = ndef_data[payload_start:payload_start + payload_len]
+
+        # Verify: TNF=0x01 (NFC Forum well-known type), Type="T" (Text)
+        if tnf != 0x01 or rec_type != [ord('T')]:
+            return FILAMENT_PROTO_ERR, None
+
+        if len(payload) < 1:
+            return FILAMENT_PROTO_ERR, None
+
+        # Text Record: first byte = status (bit 7=encoding, bits 5-0=lang code len)
+        lang_code_len = payload[0] & 0x3F
+        text_start = 1 + lang_code_len
+        if text_start >= len(payload):
+            return FILAMENT_PROTO_ERR, None
+
+        text_bytes = payload[text_start:]
+        text = bytes(text_bytes).decode('utf-8').strip()
+
+        # Parse MATERIAL#RRGGBB
+        if '#' not in text:
+            return FILAMENT_PROTO_ERR, None
+
+        parts = text.split('#', 1)
+        material_type = parts[0].upper().strip()
+        color_hex = parts[1].strip()
+
+        if material_type not in NTAG_SUPPORTED_MATERIAL_TYPES:
+            return FILAMENT_PROTO_ERR, None
+
+        if len(color_hex) != 6:
+            return FILAMENT_PROTO_ERR, None
+
+        rgb_value = int(color_hex, 16)
+
+    except (IndexError, ValueError, UnicodeDecodeError):
+        return FILAMENT_PROTO_ERR, None
+
+    info = copy.copy(FILAMENT_INFO_STRUCT)
+    info['VENDOR'] = 'Generic'
+    info['MAIN_TYPE'] = material_type
+    info['SUB_TYPE'] = 'Basic'
+    info['COLOR_NUMS'] = 1
+    info['ALPHA'] = 0xFF
+    info['RGB_1'] = rgb_value
+    info['ARGB_COLOR'] = 0xFF000000 | rgb_value
+    info['OFFICIAL'] = False
 
     return FILAMENT_PROTO_OK, info
 

--- a/klippy/extras/fm175xx_reader.py
+++ b/klippy/extras/fm175xx_reader.py
@@ -121,6 +121,7 @@ FM175XX_CARD_INFO_CLEAR                 = 1
 # RFID card type
 FM175XX_MIFARE_CARD_TYPE_UNKNOWN        = 0xFF  # unknown type
 FM175XX_MIFARE_CARD_TYPE_M1             = 0x08  # M1
+FM175XX_MIFARE_CARD_TYPE_NTAG           = 0x00  # NTAG215/216 (NFC Forum Type 2)
 
 # About M1 Card
 # EEPROM
@@ -891,6 +892,54 @@ class FM175XXReader:
         ret.out_param = card_data_tmp
         return ret
 
+    # Reader-A: NTAG, read user memory (pages 4+)
+    def __reader_a_ntag_read_user_data(self, max_pages=40) -> Fm175xxReturnVal:
+        ret = Fm175xxReturnVal()
+        user_data = []
+        page = 4  # NTAG user memory starts at page 4
+
+        while page < 4 + max_pages:
+            outbuf = [0] * 2
+            inbuf = [0] * 16
+            cmd = Fm175xxCmdMetaData()
+
+            cmd.send_crc_en = FM175XX_SET
+            cmd.recv_crc_en = FM175XX_SET
+            cmd.send_buff = outbuf
+            cmd.recv_buff = inbuf
+            cmd.send_buff[0] = 0x30  # READ command
+            cmd.send_buff[1] = page
+            cmd.bytes_to_send = 2
+            cmd.bits_to_send = 0
+            cmd.bits_to_recv = 0
+            cmd.bytes_to_recv = 16  # 4 pages * 4 bytes
+            cmd.timeout = 10
+            cmd.cmd = FM175XX_CMD_TRANSCEIVE
+            result = self.__command_exe(cmd)
+
+            if result.err_code != FM175XX_OK:
+                if len(user_data) > 0:
+                    # Partial read is OK -- we may have hit end of memory
+                    break
+                ret.err_code = FM175XX_CARD_READ_ERR
+                return ret
+
+            user_data.extend(result.out_param.recv_buff[0:16])
+
+            # Check for NDEF Terminator TLV (0xFE) in the data just read
+            if 0xFE in result.out_param.recv_buff[0:16]:
+                break
+
+            page += 4  # Advance 4 pages (each READ returns 4 pages)
+
+        if len(user_data) == 0:
+            ret.err_code = FM175XX_CARD_READ_ERR
+            return ret
+
+        ret.err_code = FM175XX_OK
+        ret.out_param = user_data
+        return ret
+
     def __bg_thread(self):
         time.sleep(0.5)
         self.__select_fm175xx_obj(FM175XX_CHANNEL_1)
@@ -983,6 +1032,22 @@ class FM175XXReader:
                                 card_op_result = FM175XX_CARD_READ_ERR
                             else:
                                 card_data = ret.out_param[0:FM175XX_M1_CARD_EEPROM_SIZE]
+                                card_op_result = FM175XX_OK
+
+                                if (self.__self_test_stage != FM175XX_SELF_TEST_STAGE_DOING):
+                                    self.__card_info_read_flag &= ~(1 << ch) & 0xFFFFFFFF
+                                else:
+                                    self.__self_test_success_cnt += 1
+                                    if (self.__card_info_deal_cb != None):
+                                        self.__card_info_deal_cb(ch, card_op, card_op_result, card_type, card_data)
+                        # NTAG215/216 (NFC Forum Type 2 Tag)
+                        elif (FM175XX_MIFARE_CARD_TYPE_NTAG == self.__picc_a.SAK[0]):
+                            card_type = FM175XX_MIFARE_CARD_TYPE_NTAG
+                            ret = self.__reader_a_ntag_read_user_data()
+                            if (FM175XX_OK != ret.err_code):
+                                card_op_result = FM175XX_CARD_READ_ERR
+                            else:
+                                card_data = ret.out_param
                                 card_op_result = FM175XX_OK
 
                                 if (self.__self_test_stage != FM175XX_SELF_TEST_STAGE_DOING):


### PR DESCRIPTION
## Summary

Add NTAG215/216 (NFC Forum Type 2 Tag) support to the FM175xx RFID reader, enabling automatic filament identification from third-party NFC-tagged spools.

## Motivation

The current RFID system only recognizes MIFARE Classic M1 cards (SAK=0x08), which limits filament auto-detection to official Snapmaker-tagged spools. Many third-party filament manufacturers/personal use NTAG215/216 NFC tags. This change allows those tags to be read and parsed automatically, providing material type and color information to the printer.

## How It Works

- After ISO14443-A activation, the reader checks the SAK byte:
  - `SAK=0x08` → existing M1 flow (unchanged)
  - `SAK=0x00` → new NTAG flow: read user memory pages, parse NDEF Text Record
- Users write a simple `MATERIAL#RRGGBB` string to the NTAG tag using any NFC app (e.g. NFC Tools)
  - Example: `PLA#FF5733` (orange PLA), `PETG#FFFFFF` (white PETG)
- The parsed material type is matched against the built-in `filament_parameters` database for temperature and flow defaults
- The filament info is delivered through the same callback pipeline as M1 cards — downstream code is unaware of the tag type

## For basic users
- Write **PLA#FF5733** as a **Text Record** on any **NTAG215/216 tag** using NFC Tools or similar app and U1 handles the rest automatically. It will now automatically detect your filaments in U1! 

## Changes (Too simple) 

| File | Change |
|------|--------|
| `klippy/extras/filament_protocol.py` | Add `ntag_ndef_data_parse()` — NDEF TLV + Text Record parser, returns `filament_info` dict with `VENDOR='Generic'`, `OFFICIAL=False` |
| `klippy/extras/fm175xx_reader.py` | Add `FM175XX_MIFARE_CARD_TYPE_NTAG` constant, `__reader_a_ntag_read_user_data()` page reader, and SAK-based `elif` branch in background thread |
| `klippy/extras/filament_detect.py` | Add `elif` routing for NTAG card type in `_fm175xx_card_info_deal_callback` |

**3 files changed, 203 insertions(+), 0 deletions(-)**

## Backward Compatibility

- No existing code modified — all changes are additive `elif` branches and new functions
- M1 card detection, HKDF authentication, and RSA signature verification are completely untouched
- No configuration changes required (`printer.cfg` works as-is)

## Supported Tag Format

| Field | Format | Example |
|-------|--------|---------|
| NDEF Record Type | Text (`T`) | — |
| Language | any (skipped) | `en` |
| Payload | `MATERIAL#RRGGBB` | `PLA#FF5733` |

Supported materials: PLA, PLA-CF, PETG, PETG-CF, PETG-HF, PCTG, ABS, ASA, TPU, PVA, PA, PA-CF, PA6-CF, PA-GF, PA6-GF, PC, PC-ABS, EVA
