### PR TITLE
Fixing MCU FW build for RP2040

### DIFF
--- a/src/rp2040/usbserial.c
+++ b/src/rp2040/usbserial.c
@@ -407,3 +407,12 @@ usbserial_init(void)
                         | USB_SIE_CTRL_PULLUP_EN_BITS);
 }
 DECL_INIT(usbserial_init);
+
+// Satisfy vendor-specific call from src/generic/usb_cdc.c
+// stubbed to allow 4rp2040 MCU FW for Snapmaker U1
+void
+usb_clear_stall(uint32_t ep, int is_in)
+{
+    (void)ep;
+    (void)is_in;
+}


### PR DESCRIPTION
Adding stubbed function `usb_clear_stall` so the linker doesn't throw a fit any more