### PR TITLE
Add slew rate of 400V/μs to TMC2240 for better cooling.

### DIFF
--- a/klippy/extras/tmc2240.py
+++ b/klippy/extras/tmc2240.py
@@ -58,8 +58,9 @@ Registers = {
 ReadRegisters = [
     "GCONF", "GSTAT", "IOIN", "DRV_CONF", "GLOBALSCALER", "IHOLD_IRUN",
     "TPOWERDOWN", "TSTEP", "TPWMTHRS", "TCOOLTHRS", "THIGH", "ADC_VSUPPLY_AIN",
-    "ADC_TEMP", "MSCNT", "MSCURACT", "CHOPCONF", "COOLCONF", "DRV_STATUS",
-    "PWMCONF", "PWM_SCALE", "PWM_AUTO", "SG4_THRS", "SG4_RESULT", "SG4_IND"
+    "ADC_TEMP", "OTW_OV_VTH", "MSCNT", "MSCURACT", "CHOPCONF", "COOLCONF", 
+    "DRV_STATUS", "PWMCONF", "PWM_SCALE", "PWM_AUTO", "SG4_THRS", "SG4_RESULT", 
+    "SG4_IND"
 ]
 
 Fields = {}
@@ -261,6 +262,9 @@ FieldFormatters.update({
     "adc_temp":         (lambda v: "0x%04x(%.1fC)" % (v, ((v - 2038) / 7.7))),
     "adc_vsupply":      (lambda v: "0x%04x(%.3fV)" % (v, v * 0.009732)),
     "adc_ain":          (lambda v: "0x%04x(%.3fmV)" % (v, v * 0.3052)),
+    "overvoltage_vth":  (lambda v: "0x%04x(%.3fV)" % (v, v * 0.009732)),
+    "overtempprewarning_vth": (lambda v:
+                               "0x%04x(%.1fC)" % (v, ((v - 2038) / 7.7))),
 })
 
 
@@ -409,6 +413,8 @@ class TMC2240:
         set_config_field(config, "tpowerdown", 10)
         #   SG4_THRS
         set_config_field(config, "sg4_angle_offset", 1)
+        #   DRV_CONF
+        set_config_field(config, "slope_control", 2)
 
 def load_config_prefix(config):
     return TMC2240(config)

--- a/lava/printer.cfg
+++ b/lava/printer.cfg
@@ -152,6 +152,7 @@ homing_retract_dist: 10
 second_homing_speed: 40
 homing_tolerance_retries: 10
 homing_backoff_dist: 5
+SET_TMC_FIELD STEPPER=stepper_x FIELD=slope_control VALUE=2
 
 [stepper_y]
 step_pin: PD2
@@ -173,6 +174,7 @@ homing_retract_dist: 10
 second_homing_speed: 40
 homing_tolerance_retries: 10
 homing_backoff_dist: 5
+SET_TMC_FIELD STEPPER=stepper_x FIELD=slope_control VALUE=2
 
 [stepper_z]
 step_pin: PE7


### PR DESCRIPTION
Recent addition to Klipper as a way of managing driver thermals (power dissipation) without adding resonance.

Values are 0, 1, 2, 3 which correspond to:
0x0: 100V/μs
0x1: 200V/μs
0x2: 400V/μs
0x3: 800V/μs

Value (2) offers the best benefit to resonance risk. This should drop the temperatures of the X and Y driver chips without additional physical cooling while not introducing any artifacting or additional resonance to printed objects.