### PR TITLE
Fix "Device or resource busy" on RFID reader after a soft Restart

### DIFF
--- a/klippy/extras/fm175xx_reader.py
+++ b/klippy/extras/fm175xx_reader.py
@@ -241,10 +241,15 @@ class FM175XXReader:
         self.__printer.register_event_handler("klippy:ready", self.__ready)
         self.__printer.register_event_handler("klippy:shutdown", self.__shutdown)
         self.__printer.register_event_handler("klippy:firmware_restart", self.__shutdown)
+        # A soft RESTART fires only klippy:disconnect (not shutdown/firmware_restart).
+        # Without releasing here the background thread keeps running in the same
+        # process and holds the gpiod lines, so the next config load fails with
+        # "[Errno 16] Device or resource busy". __shutdown is idempotent.
+        self.__printer.register_event_handler("klippy:disconnect", self.__shutdown)
 
     def __ready(self):
         # Threading
-        background_thread = threading.Thread(target=self.__bg_thread)
+        background_thread = threading.Thread(target=self.__bg_thread, daemon=True)
         background_thread.start()
 
     def __shutdown(self):


### PR DESCRIPTION
On 1.4.0, clicking **Restart** (not Firmware Restart) in the web UI leaves
Klipper unable to start, with:

    OSError: [Errno 16] Device or resource busy
    File ".../extras/fm175xx_reader.py", line ..., in __init__
      self.__soc_rst_pin.request(consumer='soc_rst_pin', ...)

Once it happens, neither Restart nor Firmware Restart recovers it; only a
reboot (or restarting the klipper service) does.

This happens because FM175XXReader` requests four gpiod lines in `__init__` and releases them
(and stops its `while 1:` worker thread) only in `__shutdown`, which is wired
to `klippy:shutdown` and `klippy:firmware_restart`.
A soft `RESTART` ends with `run_result == 'restart'`, so `Printer.run()` fires
**only** `klippy:disconnect`. `__shutdown` never runs, the non-daemon worker
thread keeps spinning in the same process and pins the old instance (so its
lines stay requested). Klipper then builds a new `FM175XXReader` in that same
process, whose `request()` hits EBUSY. Because that new `__init__` dies before
reaching its `register_event_handler` calls, no live object is left listening
for `firmware_restart` either, so the buttons can't recover it.

Register `__shutdown` on `klippy:disconnect` as well (it's idempotent), and
mark the worker thread `daemon=True` to fix it (I did it for you)
