### PR TITLE
Fixing MCU firmware builds for STM chips that don't support USB HAL

### DIFF
--- a/src/stm32/usbfs.c
+++ b/src/stm32/usbfs.c
@@ -438,3 +438,12 @@ usb_init(void)
     armcm_enable_irq(USB_IRQHandler, USBx_IRQn, 1);
 }
 DECL_INIT(usb_init);
+
+// Satisfy vendor-specific call from src/generic/usb_cdc.c
+// stubbed to allow STM MCUs that don't support USB HAL to compile for Snapmaker U1
+void
+usb_clear_stall(uint32_t ep, int is_in)
+{
+    (void)ep;
+    (void)is_in;
+}


### PR DESCRIPTION
The following change was added to allow MCU firmware building for STM chips that don't support USB HAL. Currently I have been able to successfully build and flash this version on the following chips: STM32H723, STM32G0B1, STM32F042