### PR TITLE
Drive the purifier fans through stock [fan_generic] objects

### DIFF
--- a/klippy/extras/purifier.py
+++ b/klippy/extras/purifier.py
@@ -1,9 +1,5 @@
 import logging, os, threading
 
-FAN_STATE_TURN_ON                                   = 0
-FAN_STATE_TURN_OFF                                  = 1
-FAN_STATE_TURNING_OFF                               = 2
-
 # Mode definitions
 MODE_IDLE                                           = 0 # Idle mode - original functionality
 MODE_COOL_CHAMBER                                   = 1 # Cool chamber mode - exhaust fan + temperature detection + dynamic fan control
@@ -51,8 +47,8 @@ class PurifierFanRouter:
     # both drive the fan through fan.set_speed_from_command(), as does the
     # M106/M107 fan id mapping in extras/fan.py. Routing that one method means
     # every generic entry point goes through the same path as SET_PURIFIER and
-    # keeps the power enable pin, the fan state machine, the delay-off timers
-    # and the inner fan work time accounting in sync.
+    # keeps the power enable pin, the delay-off timers, the presence gate and
+    # the inner fan work time accounting in sync.
     #
     # Everything else - set_speed(), get_mcu(), last_fan_value, max_power,
     # get_status() - delegates to the real fan.Fan, so PrinterFanGeneric and
@@ -117,8 +113,6 @@ class Purifier:
         self._power_det_value = 1
         self.last_print_time = 0
 
-        self._exhaust_fan_state = FAN_STATE_TURN_OFF
-        self._inner_fan_state = FAN_STATE_TURN_OFF
         self._exhaust_delay_timer = self.reactor.register_timer(self._exhaust_delay_timer_cb)
         self._inner_delay_timer = self.reactor.register_timer(self._inner_delay_timer_cb)
         self._work_time_monitor_timer = self.reactor.register_timer(self._work_time_monitor_timer_cb)
@@ -273,7 +267,7 @@ class Purifier:
         try:
             update_mode = 0
 
-            if self._inner_fan_state != FAN_STATE_TURN_OFF:
+            if self._inner_fan is not None and self._inner_fan.fan.last_fan_value != 0:
                 if self.print_stats is not None:
                     if self.print_stats.state not in ['printing', 'paused']:
                         if self.is_print_task_delay_turnoffing_inner == False:
@@ -351,12 +345,8 @@ class Purifier:
 
         if speed > 1.0:
             speed = 1.0
-            self._exhaust_fan_state = FAN_STATE_TURN_ON
         elif speed < 0.0001:
             speed = 0
-            self._exhaust_fan_state = FAN_STATE_TURN_OFF
-        else:
-            self._exhaust_fan_state = FAN_STATE_TURN_ON
 
         system_time = self.reactor.monotonic()
         system_time += FAN_MIN_TIME
@@ -381,12 +371,8 @@ class Purifier:
 
         if speed > 1.0:
             speed = 1.0
-            self._inner_fan_state = FAN_STATE_TURN_ON
         elif speed < 0.0001:
             speed = 0
-            self._inner_fan_state = FAN_STATE_TURN_OFF
-        else:
-            self._inner_fan_state = FAN_STATE_TURN_ON
 
         system_time = self.reactor.monotonic()
         system_time += FAN_MIN_TIME
@@ -398,7 +384,7 @@ class Purifier:
         self.last_print_time = print_time
         self.is_print_task_delay_turnoffing_inner = False
 
-        if self._inner_fan_state == FAN_STATE_TURN_ON:
+        if speed != 0:
             if self._inner_last_turn_on_time is None:
                 if self.purifier_mode in [MODE_PREHEAT_CHAMBER, MODE_HOT_CHAMBER]:
                     if self.print_stats is None or \
@@ -719,26 +705,24 @@ class Purifier:
         self.inner_fan_speed_threshold = 0
 
     def set_exhaust_fan_delay_turn_off(self, delay):
-        if self._exhaust_fan_state == FAN_STATE_TURN_OFF:
+        if self._exhaust_fan is None or self._exhaust_fan.fan.last_fan_value == 0:
             self.is_print_task_delay_turnoffing_exhaust = False
             return
 
         if delay < 1:
             self.set_exhaust_fan_speed(0)
         else:
-            self._exhaust_fan_state = FAN_STATE_TURNING_OFF
             self.reactor.update_timer(self._exhaust_delay_timer, self.reactor.monotonic() + delay)
             self.is_print_task_delay_turnoffing_exhaust = True
 
     def set_inner_fan_delay_turn_off(self, delay):
-        if self._inner_fan_state == FAN_STATE_TURN_OFF:
+        if self._inner_fan is None or self._inner_fan.fan.last_fan_value == 0:
             self.is_print_task_delay_turnoffing_inner = False
             return
 
         if delay < 1:
             self.set_inner_fan_speed(0)
         else:
-            self._inner_fan_state = FAN_STATE_TURNING_OFF
             self.reactor.update_timer(self._inner_delay_timer, self.reactor.monotonic() + delay)
             self.is_print_task_delay_turnoffing_inner = True
 

--- a/klippy/extras/purifier.py
+++ b/klippy/extras/purifier.py
@@ -1,5 +1,4 @@
 import logging, os, threading
-from . import pulse_counter
 
 FAN_STATE_TURN_ON                                   = 0
 FAN_STATE_TURN_OFF                                  = 1
@@ -44,93 +43,34 @@ DEFAULT_PURIFIER_CONFIG = {
 
 FAN_MIN_TIME = 0.200
 
-class PurifierFanTachometer:
-    def __init__(self, printer, pin, ppr, sample_time, poll_time):
-        self._frequence = pulse_counter.FrequencyCounter(printer, pin, sample_time, poll_time)
-        self._ppr = ppr
+class PurifierFanRouter:
+    # Wraps the fan.Fan instance owned by a [fan_generic] object and reroutes
+    # set_speed_from_command() into the Purifier.
+    #
+    # PrinterFanGeneric.cmd_SET_FAN_SPEED() and its control/generic_fan webhook
+    # both drive the fan through fan.set_speed_from_command(), as does the
+    # M106/M107 fan id mapping in extras/fan.py. Routing that one method means
+    # every generic entry point goes through the same path as SET_PURIFIER and
+    # keeps the power enable pin, the fan state machine, the delay-off timers
+    # and the inner fan work time accounting in sync.
+    #
+    # Everything else - set_speed(), get_mcu(), last_fan_value, max_power,
+    # get_status() - delegates to the real fan.Fan, so PrinterFanGeneric and
+    # extras/fan.py see the object they expect. Purifier.set_*_fan_speed()
+    # calls set_speed() directly, which delegates, so there is no recursion.
+    def __init__(self, fan, set_speed_cb, is_available_cb):
+        self._fan = fan
+        self._set_speed_cb = set_speed_cb
+        self._is_available = is_available_cb
 
-    def get_status(self, eventtime=None):
-        rpm = None
-        if self._frequence is not None:
-            rpm = self._frequence.get_frequency()  * 30. / self._ppr
-        return {'rpm': rpm}
-
-class PurifierFan:
-    def __init__(self,
-                 config,
-                 fan_pin,
-                 max_power=1.,
-                 kick_start_time=0.1,
-                 off_below=0.,
-                 cycle_time=0.010,
-                 hardware_pwm=False,
-                 shutdown_speed=0.,
-                 tach_pin=None,
-                 tach_ppr=2,
-                 tach_sample_time=1.,
-                 tach_poll_time=0.0015,
-                 ):
-        self.printer = config.get_printer()
-        self.reactor = self.printer.get_reactor()
-
-        self.last_fan_value = 0.
-        self.last_fan_time = 0.
-
-        self.max_power = max_power
-        self.kick_start_time = kick_start_time
-        self.off_below = off_below
-
-        # Setup pwm object
-        ppins = self.printer.lookup_object('pins')
-        self.mcu_fan = ppins.setup_pin('pwm', fan_pin)
-        self.mcu_fan.setup_max_duration(0.)
-        self.mcu_fan.setup_cycle_time(cycle_time, hardware_pwm)
-        self.mcu_fan.setup_start_value(0., max(0., min(self.max_power, shutdown_speed)))
-
-        # Setup tachometer
-        self.tachometer = None
-        if tach_pin is not None:
-            self.tachometer = PurifierFanTachometer(self.printer, tach_pin,
-                                        tach_ppr, tach_sample_time, tach_poll_time)
-
-    def get_mcu(self):
-        return self.mcu_fan.get_mcu()
-
-    def set_speed(self, print_time, value):
-        if value < self.off_below:
-            value = 0.
-        value = max(0., min(self.max_power, value * self.max_power))
-
-        if value == self.last_fan_value:
+    def set_speed_from_command(self, value, control_enable=True):
+        if value > 0 and not self._is_available():
+            logging.error("[purifier] purifier not exist!")
             return
+        self._set_speed_cb(value)
 
-        system_time = self.reactor.monotonic()
-        system_time += FAN_MIN_TIME
-        print_time = self.get_mcu().estimated_print_time(system_time)
-        print_time = max(self.last_fan_time + FAN_MIN_TIME, print_time)
-        if (value and value < self.max_power and self.kick_start_time
-            and (not self.last_fan_value or value - self.last_fan_value > .5)):
-            # Run fan at full speed for specified kick_start_time
-            self.mcu_fan.set_pwm(print_time, self.max_power)
-            print_time += self.kick_start_time
-        self.mcu_fan.set_pwm(print_time, value)
-        self.last_fan_time = print_time
-        self.last_fan_value = value
-
-    def get_speed(self):
-        return self.last_fan_value
-
-    def get_max_power(self):
-        return self.max_power
-
-    def get_status(self, eventtime):
-        status_dict = {
-            'speed': self.last_fan_value,
-        }
-        if self.tachometer is not None:
-            status_dict.update(self.tachometer.get_status(eventtime))
-
-        return status_dict
+    def __getattr__(self, name):
+        return getattr(self._fan, name)
 
 class Purifier:
     def __init__(self, config):
@@ -148,59 +88,13 @@ class Purifier:
             self.printer.update_snapmaker_config_file(self.config_path,
                         self.config_info, DEFAULT_PURIFIER_CONFIG)
 
-        # exhaust_fan
-        self._exhaust_fan = None
-        if config.get('exhaust_pin', None) is not None:
-            fan_pin = config.get('exhaust_pin', None)
-            max_power = config.getfloat('exhaust_max_power', 1., above=0., maxval=1.)
-            kick_start_time = config.getfloat('exhaust_kick_start_time', 0.1, minval=0.)
-            off_below = config.getfloat('exhaust_off_below', 0., minval=0., maxval=1.)
-            cycle_time = config.getfloat('exhaust_cycle_time', 0.010, above=0.)
-            hardware_pwm = config.getboolean('exhaust_hardware_pwm', False)
-            shutdown_speed = config.getfloat('exhaust_shutdown_speed', 0, minval=0., maxval=1.)
-            tach_pin = config.get('exhaust_tach_pin', None)
-            tach_ppr = config.getint('exhaust_tach_ppr', 2, minval=1)
-            tach_sample_time = config.getfloat('exhaust_tach_sample_time', 1., above=0.)
-            tach_poll_time = config.getfloat('exhaust_tach_poll_interval', 0.0015, above=0.)
-            self._exhaust_fan = PurifierFan(config,
-                                            fan_pin,
-                                            max_power,
-                                            kick_start_time,
-                                            off_below,
-                                            cycle_time,
-                                            hardware_pwm,
-                                            shutdown_speed,
-                                            tach_pin,
-                                            tach_ppr,
-                                            tach_sample_time,
-                                            tach_poll_time)
+        # exhaust_fan and inner fan are [fan_generic] objects so they can be
+        # driven, queried, and previewed like any other printer fan
+        exhaust_fan_name = config.get('exhaust_fan_name')
+        self._exhaust_fan = self.printer.load_object(config, 'fan_generic ' + exhaust_fan_name)
 
-        # inner fan
-        self._inner_fan = None
-        if config.get('inner_pin', None) is not None:
-            fan_pin = config.get('inner_pin')
-            max_power = config.getfloat('inner_max_power', 1., above=0., maxval=1.)
-            kick_start_time = config.getfloat('inner_kick_start_time', 0.1, minval=0.)
-            off_below = config.getfloat('inner_off_below', 0., minval=0., maxval=1.)
-            cycle_time = config.getfloat('inner_cycle_time', 0.010, above=0.)
-            hardware_pwm = config.getboolean('inner_hardware_pwm', False)
-            shutdown_speed = config.getfloat('inner_shutdown_speed', 0, minval=0., maxval=1.)
-            tach_pin = config.get('inner_tach_pin', None)
-            tach_ppr = config.getint('inner_tach_ppr', 2, minval=1)
-            tach_sample_time = config.getfloat('inner_tach_sample_time', 1., above=0.)
-            tach_poll_time = config.getfloat('inner_tach_poll_interval', 0.0015, above=0.)
-            self._inner_fan = PurifierFan(config,
-                                            fan_pin,
-                                            max_power,
-                                            kick_start_time,
-                                            off_below,
-                                            cycle_time,
-                                            hardware_pwm,
-                                            shutdown_speed,
-                                            tach_pin,
-                                            tach_ppr,
-                                            tach_sample_time,
-                                            tach_poll_time)
+        inner_fan_name = config.get('inner_fan_name')
+        self._inner_fan = self.printer.load_object(config, 'fan_generic ' + inner_fan_name)
 
         # power enable pin
         self._power_enable_pin = None
@@ -300,6 +194,14 @@ class Purifier:
         self.printer.register_event_handler("pause_resume:cancel", self._handle_cancel_print_job)
         self.printer.register_event_handler('print_stats:stop', self._handle_stop_print_job)
         self.printer.register_event_handler('print_stats:start', self._handle_start_print_job)
+
+        # Route the [fan_generic] control paths through this object
+        self._exhaust_fan.fan = PurifierFanRouter(
+            self._exhaust_fan.fan, self.set_exhaust_fan_speed,
+            lambda: self._power_detected)
+        self._inner_fan.fan = PurifierFanRouter(
+            self._inner_fan.fan, self.set_inner_fan_speed,
+            lambda: self._power_detected)
 
     def _handle_ready(self):
         self.timer_execution_counter = 0
@@ -427,9 +329,9 @@ class Purifier:
         exhaust_fan_speed = 0
         inner_fan_speed = 0
         if self._exhaust_fan is not None:
-            exhaust_fan_speed = self._exhaust_fan.get_speed()
+            exhaust_fan_speed = self._exhaust_fan.fan.last_fan_value
         if self._inner_fan is not None:
-            inner_fan_speed = self._inner_fan.get_speed()
+            inner_fan_speed = self._inner_fan.fan.last_fan_value
 
         if exhaust_fan_speed > 0 or inner_fan_speed > 0:
             self._power_enable_pin.set_digital(print_time, 1)
@@ -458,9 +360,9 @@ class Purifier:
 
         system_time = self.reactor.monotonic()
         system_time += FAN_MIN_TIME
-        print_time = self._exhaust_fan.get_mcu().estimated_print_time(system_time)
+        print_time = self._exhaust_fan.fan.get_mcu().estimated_print_time(system_time)
         print_time = max(self.last_print_time + FAN_MIN_TIME, print_time)
-        self._exhaust_fan.set_speed(print_time, speed)
+        self._exhaust_fan.fan.set_speed(print_time, speed)
         print_time += 0.01
         self._set_power_enable(print_time)
         self.last_print_time = print_time
@@ -488,9 +390,9 @@ class Purifier:
 
         system_time = self.reactor.monotonic()
         system_time += FAN_MIN_TIME
-        print_time = self._inner_fan.get_mcu().estimated_print_time(system_time)
+        print_time = self._inner_fan.fan.get_mcu().estimated_print_time(system_time)
         print_time = max(self.last_print_time + FAN_MIN_TIME, print_time)
-        self._inner_fan.set_speed(print_time, speed)
+        self._inner_fan.fan.set_speed(print_time, speed)
         print_time += 0.01
         self._set_power_enable(print_time)
         self.last_print_time = print_time
@@ -564,7 +466,7 @@ class Purifier:
         return fault_detected
     def _handle_hot_chamber_mode(self, eventtime):
         # Automatically turn off exhaust fan if it's running in current mode
-        if self._exhaust_fan is not None and self._exhaust_fan.get_speed() != 0:
+        if self._exhaust_fan is not None and self._exhaust_fan.fan.last_fan_value != 0:
             self.set_exhaust_fan_speed(0)
 
         fault_detected = self._check_inner_fan_rpm_fault(eventtime)
@@ -623,9 +525,9 @@ class Purifier:
         if (self.external_temp_sensor is not None and
             self.average_temperature is not None and
             self._exhaust_fan is not None):
-            exhaust_fan_speed = self._exhaust_fan.get_speed()
+            exhaust_fan_speed = self._exhaust_fan.fan.last_fan_value
             target_speed = exhaust_fan_speed
-            exhaust_fan_max_power = self._exhaust_fan.get_max_power()
+            exhaust_fan_max_power = self._exhaust_fan.fan.max_power
             if self.desired_chamber_temp and self.desired_chamber_temp > 0:
                 if not self.critical_temp_reported:
                     # Initialize tracking variables on first run
@@ -760,7 +662,7 @@ class Purifier:
         #                        f"\nInner Fan Speed: {inner_fan_speed}, Exhaust Fan Speed: {exhaust_fan_speed}, "
         #                        f"\nDesired Temp: {self.desired_chamber_temp}°C, Preheat Wait: {self.preheat_wait_enabled}, "
         #                        f"\nLast Check Temp: {self.preheat_check_last_temp}, Timeout: {self.preheat_check_timeout_time}")
-        if self._exhaust_fan is not None and self._exhaust_fan.get_speed() != 0:
+        if self._exhaust_fan is not None and self._exhaust_fan.fan.last_fan_value != 0:
             self.set_exhaust_fan_speed(0)
 
         fault_detected = self._check_inner_fan_rpm_fault(eventtime)
@@ -857,7 +759,7 @@ class Purifier:
         }
         if self._inner_fan is not None:
             status_dict.update({'inner_fan_work_time': round(self.config_info['inner_work_time'], 1)})
-            if 'rpm' in inner_fan_status:
+            if inner_fan_status.get('rpm') is not None:
                 status_dict.update({'inner_fan_rpm': inner_fan_status['rpm']})
 
         if exhaust_fan_status is not None:

--- a/lava/printer.cfg
+++ b/lava/printer.cfg
@@ -737,6 +737,8 @@ cycle_time: 0.005
 shutdown_speed: 0
 aux_cool_fan: cavity_fan
 aux_cool_fan_id: 2
+exhaust_fan: exhaust_fan
+exhaust_fan_id: 3
 
 [heater_fan e0_nozzle_fan]
 pin: !e0:PB0

--- a/lava/printer.cfg
+++ b/lava/printer.cfg
@@ -263,20 +263,24 @@ shutdown_speed: 0
 white_pin: PA10
 cycle_time: 0.003333
 
+[fan_generic exhaust_fan]
+pin: !PA8
+max_power: 1.0
+cycle_time: 0.001
+hardware_pwm: True
+
+[fan_generic circulation_fan]
+pin: !PA9
+max_power: 1.0
+cycle_time: 0.001
+hardware_pwm: True
+tachometer_pin: PA6
+tachometer_ppr: 2
+tachometer_poll_interval: 0.0005
+
 [purifier]
-# exhaust fan
-exhaust_pin: !PA8
-exhaust_max_power: 1.0
-exhaust_cycle_time: 0.001
-exhaust_hardware_pwm: True
-# inner fan
-inner_pin: !PA9
-inner_max_power: 1.0
-inner_cycle_time: 0.001
-inner_hardware_pwm: True
-inner_tach_pin: PA6
-inner_tach_ppr: 2
-inner_tach_poll_interval: 0.0005
+exhaust_fan_name: exhaust_fan
+inner_fan_name: circulation_fan
 # global
 power_enable_pin: PE15
 power_det_pin: PA7


### PR DESCRIPTION
## Summary

Moves the purifier's exhaust and inner fans onto stock Klipper `[fan_generic]` objects, so they are addressable like every other fan on the machine — `SET_FAN_SPEED FAN=exhaust_fan`, `M106 P3`, the `control/generic_fan` endpoint, `printer.fan_generic circulation_fan` in the object query API, and the Fluidd/Mainsail fan panels.

Today both fans are driven by `PurifierFan`/`PurifierFanTachometer`, private classes inside `purifier.py` that reimplement what `fan.Fan` already does (PWM setup, kick-start, tachometer). Nothing outside `SET_PURIFIER` and the `control/purifier` webhook can see or drive them.

Net effect on `klippy/extras/purifier.py`: **-114 lines** (1197 → 1083).

## Approach

1. `[purifier]` no longer takes raw fan pins. The pin/PWM/tachometer config moves into `[fan_generic exhaust_fan]` and `[fan_generic circulation_fan]`, and `[purifier]` references them by name via `exhaust_fan_name` / `inner_fan_name`. `Purifier.__init__` resolves them with `load_object(config, 'fan_generic ' + name)`.
2. `PurifierFan` and `PurifierFanTachometer` are deleted.
3. `PurifierFanRouter` wraps the `fan.Fan` each `[fan_generic]` object holds and overrides **only** `set_speed_from_command()`, delegating everything else through `__getattr__`.

Step 3 is what makes step 1 safe, and is the part worth reviewing.

## Why the router is required

`[fan_generic]` registers its own `SET_FAN_SPEED` mux command and `control/generic_fan` endpoint, and `extras/fan.py` reaches through `fan_obj.fan.set_speed_from_command()` for `M106`/`M107` fan-id mapping (`fan.py:192`, `fan.py:206`) and for power-loss resume (`resume_all_fan_speed()`, `fan.py:178`).

All of those drive `fan.Fan` directly, bypassing `set_exhaust_fan_speed()`/`set_inner_fan_speed()` and everything they own:

- `power_enable_pin` — the fan power rail. Never asserted, so the fan gets a PWM duty cycle with no power.
- the delay-off timers
- the `_power_detected` presence gate
- `inner_work_time`, which tracks filter life

Every one of those entry points converges on `set_speed_from_command()`, so routing that single method covers all of them, with no changes to `fan_generic.py`, no dependency on config section order, and no reliance on `gcode`/`webhooks` internals. `Purifier.set_*_fan_speed()` calls the real fan's `set_speed()`, which the router does not intercept, so there is no recursion.

Measured without the router, on hardware: a circulation fan started with `SET_FAN_SPEED` keeps spinning at 4652 rpm through both `SET_PURIFIER FAN=inner SPEED=0` and `SET_PURIFIER_MODE MODE=0`, because `set_inner_fan_delay_turn_off()` returns early on `FAN_STATE_TURN_OFF`.

## Fan state enum removed

With one write path per fan, `_exhaust_fan_state`/`_inner_fan_state` no longer carry anything not already in `fan.Fan.last_fan_value`:

| old | derived |
| --- | --- |
| `state == FAN_STATE_TURN_OFF` | `last_fan_value == 0` |
| `state != FAN_STATE_TURN_OFF` | `last_fan_value != 0` |
| `state == FAN_STATE_TURN_ON` | clamped `speed != 0` |

`FAN_STATE_TURNING_OFF` only ever meant "not off" — the fan is still spinning through the delay-off window — so the derived checks give the same answer. The speed clamp is kept, which is what keeps the accrual trigger equivalent.

## Unchanged

`SET_PURIFIER`, `GET_PURIFIER`, `SET_PURIFIER_MODE`, `WAIT_CHAMBER_TEMP` and the `control/purifier` webhook are untouched, as are the chamber modes, dynamic cooling ramp, RPM fault detection, presence detection and the `purifier` status object.

## Config change

`[purifier]` sections carrying raw pins will no longer load — `exhaust_fan_name`/`inner_fan_name` are required. `lava/printer.cfg` is updated to match; see the diff for the exact split.

The module and the config ship together in a firmware image, so the two always move as a pair and there is no migration path to support. The required-with-no-default choice is deliberate on that basis: a `[purifier]` missing either key is a packaging error worth failing loudly on, not a machine that should come up with a silently absent fan.

## M106/M107 fan-id mapping

`extras/fan.py` already carries an `exhaust_fan`/`exhaust_fan_id` pair under a comment reading "exhaust fan / purifier fan", and Snapmaker's own factory configs use it (`factory2.cfg` sets `exhaust_fan: purifier`, `exhaust_fan_id: 3`). It was unusable from `printer.cfg` because the purifier's fans were not `[fan_generic]` objects and `fan.py` resolves the mapping with `lookup_object("fan_generic <name>")`. `lava/printer.cfg` now points it at the exhaust fan, so slicer-emitted `M106 P3`/`M107 P3` drive it.

This is also the case that makes the router necessary rather than merely tidy: `cmd_M106`/`cmd_M107` call `fan_obj.fan.set_speed_from_command()` directly (`fan.py:192`, `fan.py:206`) and never touch the `SET_FAN_SPEED` mux command, so intercepting at the dispatch layer would not have covered them.

## Testing

On a U1 with a purifier attached, Klipper `1.6.0.267_20260815150420`:

| check | result |
| --- | --- |
| `SET_FAN_SPEED FAN=circulation_fan SPEED=0.6` | 4645 rpm |
| `SET_PURIFIER FAN=inner SPEED=0` after the above | 0 rpm |
| `SET_FAN_SPEED FAN=circulation_fan SPEED=1.0` | 6294 rpm |
| `DELAY_OFF=5` against a `SET_FAN_SPEED`-started fan | armed, fired at ~5s |
| `control/generic_fan` `S=70`, then `SET_PURIFIER ... SPEED=0` | 0.7 → 0 |
| `SET_FAN_SPEED FAN=exhaust_fan SPEED=0.5` | `purifier` reports `exhaust_fan.speed: 0.5` |
| `SET_PURIFIER FAN=inner SPEED=0.3` | reported as 0.3 / 3520 rpm in the generic view |
| presence gate on the generic path | `SET_FAN_SPEED` refused while `power_detected` is false |
| `M106 P3 S128` | speed 0.502 (128/255) |
| `M106 P3 S255` | speed 1.0 |
| `SET_PURIFIER FAN=exhaust SPEED=0` after `M106 P3` | 0 — purifier can stop what `M106` started |
| `M106 P3 S200` then `M107 P3` | 0.784 → 0 |

The delay-off row is the meaningful one for the state removal: delay-off only arms when the fan reads non-zero, so a timer firing on a fan that `SET_FAN_SPEED` started shows the derived check matches the old enum.

## Credit

The `[fan_generic]` migration and the `PurifierFan` removal are @paxx12's design, from https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware/pull/670. This PR carries the same approach against a stock 1.6.0 tree, adds the router, and drops the state enum. The two implementations converged independently and are functionally equivalent.

Offering it upstream so the community firmware and mainline do not diverge on this, and so the fix lands where the `exhaust_fan_id` hook already lives.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
